### PR TITLE
Default status page to close only button

### DIFF
--- a/ui/components/app/transaction-list-item/smart-transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/smart-transaction-list-item.component.js
@@ -37,7 +37,7 @@ export default function SmartTransactionListItem({
   let displayedStatusKey;
   if (status === 'pending') {
     displayedStatusKey = TRANSACTION_GROUP_STATUSES.PENDING;
-  } else if (status.startsWith('cancelled')) {
+  } else if (status?.startsWith('cancelled')) {
     displayedStatusKey = TRANSACTION_GROUP_STATUSES.CANCELLED;
   }
   const showCancelSwapLink =

--- a/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
+++ b/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
@@ -150,7 +150,9 @@ export default function SmartTransactionStatus() {
 
   const isSmartTransactionPending = smartTransactionStatus === 'pending';
   const showCloseButtonOnly =
-    isSmartTransactionPending || smartTransactionStatus === 'success';
+    smartTransactionStatus === '' ||
+    isSmartTransactionPending ||
+    smartTransactionStatus === 'success';
 
   useEffect(() => {
     stxStatusPageLoadedEvent();

--- a/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
+++ b/ui/pages/swaps/smart-transaction-status/smart-transaction-status.js
@@ -72,7 +72,7 @@ export default function SmartTransactionStatus() {
     getSmartTransactionsOptInStatus,
   );
   const smartTransactionsEnabled = useSelector(getSmartTransactionsEnabled);
-  let smartTransactionStatus = '';
+  let smartTransactionStatus = 'pending';
   let latestSmartTransaction = {};
   let latestSmartTransactionUuid;
 
@@ -93,7 +93,7 @@ export default function SmartTransactionStatus() {
     // and without this code a user would briefly (~1 - 2s) see a status page for the previous smart transaction.
     latestSmartTransaction = {};
     latestSmartTransactionUuid = null;
-    smartTransactionStatus = '';
+    smartTransactionStatus = 'pending';
   }
   const [timeLeftForPendingStxInSec, setTimeLeftForPendingStxInSec] = useState(
     () => {
@@ -150,9 +150,7 @@ export default function SmartTransactionStatus() {
 
   const isSmartTransactionPending = smartTransactionStatus === 'pending';
   const showCloseButtonOnly =
-    smartTransactionStatus === '' ||
-    isSmartTransactionPending ||
-    smartTransactionStatus === 'success';
+    isSmartTransactionPending || smartTransactionStatus === 'success';
 
   useEffect(() => {
     stxStatusPageLoadedEvent();

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -50,7 +50,7 @@ export const smartTransactionsListSelector = (state) =>
     .map((stx) => ({
       ...stx,
       transactionType: 'smart',
-      status: stx.status.startsWith('cancelled') ? 'cancelled' : stx.status,
+      status: stx.status?.startsWith('cancelled') ? 'cancelled' : stx.status,
     }));
 
 export const selectedAddressTxListSelector = createSelector(


### PR DESCRIPTION
Fixes: #

Explanation:  
On the status page, instead of defaulting to dual buttons, we want to default to only showing the close button by defining `showCloseButtonOnly` to account for `smartTransactionStatus === ''`.

We want to show only the close button when the status page first shows up and when the status page first loads, `smartTransactionStatus` is an empty string `''` because the last smart transaction has not finished being submitted yet. So making this change will the page to only display the close button.

I do not foresee this change presenting any issues because there are few circumstances in which `smartTransactionStatus` is empty (if the smart transaction has not finished submitting and the latest smart transaction is different than a previous one). In both of these cases, we'd like to show only the close button and not the try again button as well.