### PR TITLE
Reset submit clicked after user turns off current stx

### DIFF
--- a/ui/pages/swaps/view-quote/view-quote.js
+++ b/ui/pages/swaps/view-quote/view-quote.js
@@ -797,6 +797,21 @@ export default function ViewQuote() {
     }
   }, [dispatch, viewQuotePageLoadedEvent, reviewSwapClickedTimestamp]);
 
+  useEffect(() => {
+    // if smart transaction error is turned off, reset submit clicked boolean
+    if (
+      !currentSmartTransactionsEnabled &&
+      currentSmartTransactionsError &&
+      submitClicked
+    ) {
+      setSubmitClicked(false);
+    }
+  }, [
+    currentSmartTransactionsEnabled,
+    currentSmartTransactionsError,
+    submitClicked,
+  ]);
+
   const transaction = {
     userFeeLevel: swapsUserFeeLevel || GAS_RECOMMENDATIONS.HIGH,
     txParams: {


### PR DESCRIPTION
Explanation: 
The submit button doesn't show when a user runs into a smart transaction error and tries to re-submit the transaction through the normal flow. This happens because when the user submits the smart transaction, we set the state variable `submitClicked` to true and the submit button disables when this variable is true.

To fix it, I reset the `submitClicked` variable back to false when the user selects to try out the transaction through the normal flow. Since the action to try out the normal transaction flow happens outside of the view quote component, there's no direct way to track when the user clicks the button but there are redux state variables that keep track of this action. When this happens, `currentSmartTransactionEnabled` will be false while `currentSmartTransactionError` will be true. This is the only situation that will cause these two variables to have these values. Therefore, it's safe to conclude that through these variables we can reset the `submitClicked` variable accurately when this action fires off.
