### PR TITLE
Refactored existing tests and added more

### DIFF
--- a/test/e2e/swaps/swap-eth.spec.js
+++ b/test/e2e/swaps/swap-eth.spec.js
@@ -6,6 +6,7 @@ const {
   reviewQuote,
   waitForTransactionToComplete,
   checkActivityTransaction,
+  changeExchangeRate,
 } = require('./shared');
 
 describe('Swap Eth for another Token', function () {
@@ -25,7 +26,7 @@ describe('Swap Eth for another Token', function () {
           swapTo: 'USDC',
         });
         await reviewQuote(driver, {
-          amount: '0.001',
+          amount: 0.001,
           swapFrom: 'TESTETH',
           swapTo: 'USDC',
         });
@@ -36,12 +37,12 @@ describe('Swap Eth for another Token', function () {
           swapTo: 'DAI',
         });
         await reviewQuote(driver, {
-          amount: '0.003',
+          amount: 0.003,
           swapFrom: 'TESTETH',
           swapTo: 'DAI',
         });
         await driver.clickElement({ text: 'Swap', tag: 'button' });
-        await waitForTransactionToComplete(driver, 'DAI');
+        await waitForTransactionToComplete(driver, { tokenName: 'DAI' });
         await checkActivityTransaction(driver, {
           index: 0,
           amount: '0.003',
@@ -57,7 +58,7 @@ describe('Swap Eth for another Token', function () {
       },
     );
   });
-  it('Completes a Swap between Eth and Dai', async function () {
+  it('Completes a Swap between ETH and DAI after changing initial rate', async function () {
     await withFixtures(
       {
         ...withFixturesOptions,
@@ -70,12 +71,19 @@ describe('Swap Eth for another Token', function () {
           swapTo: 'DAI',
         });
         await reviewQuote(driver, {
-          amount: '2',
+          amount: 2,
           swapFrom: 'TESTETH',
           swapTo: 'DAI',
         });
+        await changeExchangeRate(driver);
+        await reviewQuote(driver, {
+          amount: 2,
+          swapFrom: 'TESTETH',
+          swapTo: 'DAI',
+          skipCounter: true,
+        });
         await driver.clickElement({ text: 'Swap', tag: 'button' });
-        await waitForTransactionToComplete(driver, 'DAI');
+        await waitForTransactionToComplete(driver, { tokenName: 'DAI' });
         await checkActivityTransaction(driver, {
           index: 0,
           amount: '2',


### PR DESCRIPTION
Explanation:  Due to a major UI change for Swap I had to refactor the e2e tests. Also we added TestID's on the dev side so we are now using those in the selectors

Manual testing steps:  
yarn test:e2e:single test/e2e/swaps/swap-eth.spec.js --browser chrome
yarn test:e2e:single test/e2e/swaps/swaps-notifications.spec.js --browser chrome